### PR TITLE
Remove need for item rule by using non_local_items option set

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,7 @@ class BingoWorld(World):
             if name in squares:
                 item_pool.append(self.create_item(name))
         self.multiworld.itempool += item_pool
+        self.options.non_local_items.value = set(squares)
 
     def create_regions(self) -> None:
         # Create regions.
@@ -76,10 +77,8 @@ class BingoWorld(World):
 
         for bingo in bingo_names:
             self.get_location(bingo).access_rule = get_bingo_rule(bingo, self)
-            self.get_location(bingo).item_rule = lambda item: item.name not in all_keys
 
         self.get_location("Bingo (ALL)").access_rule = special_rule(self, all_keys)
-        self.get_location("Bingo (ALL)").item_rule = lambda item: item.name not in all_keys
 
         # Don't allow incorrect values for required bingos
         self.required_bingos = self.options.required_bingos.value


### PR DESCRIPTION
item rules are way slower since it makes it so the function has to be called every single time an item is attempted to be placed on each bingo location. Using the non_local_items option set to instead make sure all key items are placed in other worlds so the bingo locations don't need to have those checks anymore.