### PR TITLE
Fixing grabbing two-digit numbers

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -62,7 +62,7 @@ def extract_bingo_spaces(location):
 
     # Determine the range of rows and columns
     start_row = start[0]  # 'A', 'B', 'C', etc.
-    start_col = int(start[1])  # 1, 2, 3, etc.
+    start_col = int(start[1:])  # 1, 2, 3, etc.
     end_row = end[0]  # 'A', 'B', 'C', etc.
     end_col = int(end[1:])  # 1, 2, 3, etc.
 


### PR DESCRIPTION
Tested with:
```py
    if f"{start}-{end}" != f"{start_row}{start_col}-{end_row}{end_col}":
        print("UNEQUAL")
```
Before it would print for `{'A10'} {'J10'} {'A'} {1} {'J'} {10}` now it does not print at all.